### PR TITLE
fix: v0.3.2 - Data parsing error

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2025-10-10
+
+### Fixed
+- date parsing bug that caused ValueError when running shomei
+- was splitting the date string wrong, ended up with just "2025" instead of the full datetime
+
 ## [0.3.0] - 2025-10-09
 
 ### Major Simplification - Complete Rewrite!

--- a/shomei/__init__.py
+++ b/shomei/__init__.py
@@ -4,6 +4,6 @@ shōmei - a CLI tool that safely updates your personal github graph to reflect t
 transforms your commits into safe, sanitized commits, and publishes them to your personal github profile, so your contribution graph reflects your real effort.
 """
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __author__ = "shomei contributors"
 __description__ = "update your personal github graph to reflect the work you did"

--- a/shomei/cli.py
+++ b/shomei/cli.py
@@ -53,8 +53,10 @@ def get_commits_by_author(email):
                 parts = line.split('|', 2)
                 if len(parts) >= 2:
                     commit_hash, date_str = parts[0], parts[1]
-                    # parse the ISO date
-                    date = datetime.fromisoformat(date_str.strip().replace(' ', 'T').split('+')[0].split('-')[0])
+                    # parse the ISO date (format: "2025-01-09 10:30:45 +0100")
+                    # remove timezone and convert space to T for ISO format
+                    clean_date = date_str.strip().replace(' ', 'T').split('+')[0]
+                    date = datetime.fromisoformat(clean_date)
                     commits.append({'hash': commit_hash, 'date': date})
 
         return commits


### PR DESCRIPTION
## fix: v0.3.2 - date parsing error fixed a bug where shomei crashed with a ValueError when parsing commit dates. 

the date parsing logic was doing an extra split that left just the year instead of the full datetime. what changed:
- removed the bad .split('-')[0] that was breaking things
- dates now parse correctly
