### PR TITLE
feat: ensures the provided username is linked to a different GitHub

### DIFF
--- a/shomei/cli.py
+++ b/shomei/cli.py
@@ -70,7 +70,7 @@ def cli(private, dry_run):
     personal_username = None
     while True:
         username = click.prompt("Your personal GitHub username")
-        valid, message = validate_github_username(username)
+        valid, message = validate_github_username(git_name, username)
 
         if not valid:
             console.print(f"[red]{message}[/red]")

--- a/shomei/validators.py
+++ b/shomei/validators.py
@@ -95,12 +95,14 @@ def validate_github_token(token):
 
     return True, None
 
-def validate_github_username(username):
+def validate_github_username(working_dir_username, potential_username):
     """
     Validate whether the given username exists on GitHub.
+    Makes sure new username is a different GitHub account than one in the working directory
 
     Args:
-        username: The GitHub username to validate
+        working_dir_username: GitHub username in the working directory
+        potential_username: The GitHub username to validate
 
     Returns:
         tuple: (exists: bool, error_message: str or None)
@@ -108,15 +110,18 @@ def validate_github_username(username):
     Notes:
         Print a warning if given username doesn't exist but don't block.
     """
-    if not username or len(username.strip()) == 0:
+    if not potential_username or len(potential_username.strip()) == 0:
         return False, "username cannot be empty"
+    
+    if potential_username == working_dir_username:
+        return False, f"This repo is already using '{potential_username}'"
 
-    username = username.strip()
-    response = requests.get(f"https://api.github.com/users/{username}", timeout=10)
+    potential_username = potential_username.strip()
+    response = requests.get(f"https://api.github.com/users/{potential_username}", timeout=10)
     if response.status_code == 404:
-        return False, f"GitHub user '{username}' does not exist"
+        return False, f"GitHub user '{potential_username}' does not exist"
     elif response.status_code == 200:
-        return True, f"GitHub user '{username}' exists"
+        return True, f"GitHub user '{potential_username}' exists"
     else:
-        return False, f"Error checking GitHub user '{username}': {response.status_code}"
+        return False, f"Error checking GitHub user '{potential_username}': {response.status_code}"
         


### PR DESCRIPTION
Added another conditional inside of validate_github_username to make sure the submitted username is different than the one inside the working directory. This ensures activity is not tracked within the same account more than once. 

* validate_github_username now accepts two inputs: working_dir_username and potential_username
* added if condition for checking duplicates
* changed 'username' to 'potential_username' inside working_dir_username, potential_username