### PR TITLE
feature: add non-interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ lots of developers use separate emails for work, and when they leave a company, 
 - **dead simple** - one command, that's it
 - **contribution proof** - updates your GitHub graph to show you were actually working
 - **your commits only** - filters by your email, won't touch anyone else's work
+- **incremental syncs** - remembers mirrored commit hashes and only adds new work
 - **dry-run mode** - preview before you commit (pun intended)
 - **private repos** - option to mirror to a private repo if you want
 
@@ -114,10 +115,19 @@ shomei --yes
 
 1. scans your git log for commits with your email
 2. extracts just the commit dates (nothing else!)
-3. creates a new repo on your personal GitHub
+3. creates a new repo on your personal GitHub, or finds the existing mirror
 4. uses GitHub's API to create empty commits with those dates
-5. generates a beautiful README for your mirrored repo
-6. boom, your contribution graph now shows your real activity
+5. records each successfully mirrored source commit hash in `.shomei/state.json`
+6. generates a beautiful README for your mirrored repo
+7. boom, your contribution graph now shows your real activity
+
+Run shōmei again whenever you have new commits. It reads the local state file
+and only syncs source commits whose hashes have not been recorded yet. The
+state file is kept in the source repository's ignored `.shomei/` directory and
+contains no source code, messages, paths, or secrets.
+
+Mirrors created by an older shōmei version are migrated automatically from
+their existing generated commit timestamps on the next run.
 
 **important**: no code ever leaves your machine. we only send timestamps to GitHub's API. your company's IP stays exactly where it is.
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,41 @@ shomei --dry-run
 shomei --private
 ```
 
+### non-interactive / CI usage
+
+pass everything up front and shōmei runs without prompting. it also simplifies
+its output (no logo, panels, or spinners) whenever it detects a non-interactive
+terminal (a pipe, cron job, or CI), and exits non-zero on failure.
+
+```bash
+# fully scripted run — no prompts, fails fast if a value is missing
+shomei \
+  --username your-personal-username \
+  --repo-name work-mirror \
+  --token ghp_your_token \
+  --non-interactive
+
+# the token can also come from the environment (handy for CI secrets)
+export SHOMEI_GITHUB_TOKEN=ghp_your_token
+shomei -u your-personal-username -r work-mirror --non-interactive
+
+# override the git identity used to detect commits / greeting
+shomei -u your-personal-username -e work@company.com -n "Your Name" --non-interactive
+
+# skip only the confirmation prompt but keep prompting for anything missing
+shomei --yes
+```
+
+| flag | description |
+|------|-------------|
+| `-u, --username` | your personal GitHub username |
+| `-r, --repo-name` | name for the mirror repo (default: `<repo>-mirror`) |
+| `-t, --token` | GitHub token (or set `SHOMEI_GITHUB_TOKEN`) |
+| `-e, --email` | git author email to filter commits (default: `git config user.email`) |
+| `-n, --name` | your name for the greeting (default: `git config user.name`) |
+| `-y, --yes` | skip confirmation prompts |
+| `--non-interactive` | never prompt; fail if a required value is missing (implies `--yes`) |
+
 ## how it works
 
 1. scans your git log for commits with your email

--- a/shomei/__init__.py
+++ b/shomei/__init__.py
@@ -17,6 +17,7 @@ from .git_utils import get_git_user_email, get_repo_name, get_commits_by_author
 from .github_api import (
     create_github_repo,
     get_main_branch_sha,
+    get_mirrored_commit_dates,
     create_empty_commit,
     update_branch_ref,
     update_repo_readme
@@ -35,6 +36,7 @@ __all__ = [
     # github api
     'create_github_repo',
     'get_main_branch_sha',
+    'get_mirrored_commit_dates',
     'create_empty_commit',
     'update_branch_ref',
     'update_repo_readme',

--- a/shomei/cli.py
+++ b/shomei/cli.py
@@ -4,7 +4,9 @@ shōmei - mirror your work commits to personal GitHub without leaking IP.
 super simple, super safe.
 """
 
+import sys
 import time
+from contextlib import nullcontext
 from datetime import timezone
 import click
 from rich.console import Console
@@ -28,11 +30,29 @@ from .readme_generator import create_readme_content
 console = Console()
 
 
+def _die(message, hint=None):
+    """Print an error and exit with a non-zero status."""
+    console.print(f"[red]!!! {message}[/red]")
+    if hint:
+        console.print(f"[dim]{hint}[/dim]")
+    sys.exit(1)
+
+
 @click.command()
 @click.option('--private', is_flag=True, help='make the mirror repo private')
 @click.option('--dry-run', is_flag=True, help='preview what would happen without actually doing it')
+@click.option('-u', '--username', help='your personal GitHub username')
+@click.option('-r', '--repo-name', 'mirror_repo_name', help='name for the mirror repo (default: <repo>-mirror)')
+@click.option('-t', '--token', envvar='SHOMEI_GITHUB_TOKEN',
+              help="GitHub personal access token (needs 'repo' scope). "
+                   "can also be set via the SHOMEI_GITHUB_TOKEN env var")
+@click.option('-e', '--email', help='git author email to filter commits (default: git config user.email)')
+@click.option('-n', '--name', 'display_name', help='your name for the greeting (default: git config user.name)')
+@click.option('-y', '--yes', is_flag=True, help='skip all confirmation prompts (assume yes)')
+@click.option('--non-interactive', is_flag=True,
+              help='never prompt; fail if any required value is missing. implies --yes')
 @click.version_option(version=__version__, prog_name='shōmei')
-def cli(private, dry_run):
+def cli(private, dry_run, username, mirror_repo_name, token, email, display_name, yes, non_interactive):
     """
     shōmei - proof of your work
 
@@ -43,61 +63,110 @@ def cli(private, dry_run):
     work email, and it'll create a matching commit history on your personal
     GitHub. your contribution graph gets updated, recruiters stop thinking
     you've been on vacation for a year, everyone's happy.
+
+    for CI / scripted use, pass everything up front, e.g.:
+
+        shomei -u me -r work-mirror -t ghp_xxx --non-interactive
     """
-    # show the logo because it looks sick
-    print_logo()
+    # a real terminal we can talk to, or a pipe/CI environment?
+    can_prompt = sys.stdin.isatty() and not non_interactive
+    # simplify output (no logo/panels/spinners) when there's no interactive terminal
+    plain = non_interactive or not sys.stdout.isatty()
+    # non-interactive runs never wait on a confirmation
+    assume_yes = yes or non_interactive or not can_prompt
+
+    # show the logo because it looks sick (but not when piped/scripted)
+    if not plain:
+        print_logo()
 
     # figure out where we are
-    corporate_email = get_git_user_email()
+    corporate_email = email or get_git_user_email()
     if not corporate_email:
-        console.print("[red]!!! no git user found. are you in a git repo?[/red]")
-        console.print("[dim]try: git config user.email[/dim]")
-        return
-    
-    git_name = get_git_user_name()
+        _die("no git user email found. are you in a git repo?",
+             "try: git config user.email  (or pass --email)")
+
+    git_name = display_name or get_git_user_name()
     if not git_name:
-        console.print("[red]!!! no git user name found. are you in a git repo?[/red]")
-        console.print("[dim]try: git config user.name[/dim]")
-        return
+        if can_prompt:
+            _die("no git user name found. are you in a git repo?",
+                 "try: git config user.name  (or pass --name)")
+        # a name is only cosmetic; don't block a scripted run over it
+        git_name = corporate_email
 
     repo_name = get_repo_name()
 
-    console.print(f"Hello, [bold]{git_name}[/bold] :wave:\n")
-    console.print(f"[bold cyan]current git email:[/bold cyan] {corporate_email}")
-    console.print(f"[bold cyan]current repo:[/bold cyan] {repo_name}")
-    console.print()
-     
-    personal_username = None
-    while True:
-        username = click.prompt("Your personal GitHub username")
+    if plain:
+        console.print(f"git email: {corporate_email}")
+        console.print(f"repo: {repo_name}")
+    else:
+        console.print(f"Hello, [bold]{git_name}[/bold] :wave:\n")
+        console.print(f"[bold cyan]current git email:[/bold cyan] {corporate_email}")
+        console.print(f"[bold cyan]current repo:[/bold cyan] {repo_name}")
+        console.print()
+
+    # --- personal GitHub username ---
+    if username:
+        username = username.strip()
         valid, message = validate_github_username(username)
-
         if not valid:
-            console.print(f"[red]{message}[/red]")
-            console.print("[dim]Please try again[/dim]\n")
-            continue
+            _die(message)
+        if not plain:
+            console.print(f"[green]{message}[/green]\n")
+    elif not can_prompt:
+        _die("missing personal GitHub username", "pass --username / -u")
+    else:
+        while True:
+            candidate = click.prompt("Your personal GitHub username")
+            valid, message = validate_github_username(candidate)
+            if not valid:
+                console.print(f"[red]{message}[/red]")
+                console.print("[dim]Please try again[/dim]\n")
+                continue
+            console.print(f"[green]{message}[/green]\n")
+            if click.confirm(f"Username: {candidate}, is that correct?", default=True):
+                username = candidate.strip()
+                break
 
-        console.print(f"[green]{message}[/green]\n")
-
-        if click.confirm(f"Username: {username}, is that correct?", default=True):
-            personal_username = username
-            break
-
-    # get repo name with validation
+    # --- mirror repo name ---
     suggested_name = f"{repo_name}-mirror"
-    mirror_repo_name = None
-    while not mirror_repo_name:
-        repo_input = click.prompt("what should we call the mirror repo?", default=suggested_name)
-        valid, error = validate_repo_name(repo_input)
-        if valid:
-            mirror_repo_name = repo_input.strip()
-        else:
-            console.print(f"[red]x {error}[/red]")
-            console.print("[dim]repo names can only contain letters, numbers, hyphens, underscores, and periods[/dim]\n")
+    if mirror_repo_name:
+        valid, error = validate_repo_name(mirror_repo_name)
+        if not valid:
+            _die(error,
+                 "repo names can only contain letters, numbers, hyphens, underscores, and periods")
+        mirror_repo_name = mirror_repo_name.strip()
+    elif not can_prompt:
+        # a sensible default is fine for scripted runs
+        valid, error = validate_repo_name(suggested_name)
+        if not valid:
+            _die(f"could not derive a valid mirror repo name ('{suggested_name}')",
+                 "pass --repo-name / -r")
+        mirror_repo_name = suggested_name
+    else:
+        while not mirror_repo_name:
+            repo_input = click.prompt("what should we call the mirror repo?", default=suggested_name)
+            valid, error = validate_repo_name(repo_input)
+            if valid:
+                mirror_repo_name = repo_input.strip()
+            else:
+                console.print(f"[red]x {error}[/red]")
+                console.print("[dim]repo names can only contain letters, numbers, hyphens, underscores, and periods[/dim]\n")
 
+    # --- token ---
     if dry_run:
-        console.print("\n[yellow]! DRY RUN MODE - nothing will actually be created ![/yellow]\n")
+        if not plain:
+            console.print("\n[yellow]! DRY RUN MODE - nothing will actually be created ![/yellow]\n")
+        else:
+            console.print("dry-run: nothing will be created")
         token = "dry-run"  # placeholder for dry run
+    elif token:
+        valid, error = validate_github_token(token)
+        if not valid:
+            _die(error)
+        token = token.strip()
+    elif not can_prompt:
+        _die("missing GitHub token",
+             "pass --token / -t or set the SHOMEI_GITHUB_TOKEN env var")
     else:
         token = None
         while not token:
@@ -109,65 +178,80 @@ def cli(private, dry_run):
                 console.print(f"[red]!!! {error}[/red]")
                 console.print("[dim]please try again[/dim]\n")
 
-    console.print()
+    if not plain:
+        console.print()
 
     # get all commits by this email
-    with console.status("[bold cyan]🔍 scanning commit history...[/bold cyan]"):
+    scan_ctx = nullcontext() if plain else console.status("[bold cyan]🔍 scanning commit history...[/bold cyan]")
+    with scan_ctx:
         commits = get_commits_by_author(corporate_email)
 
     if not commits:
-        console.print("[yellow]!!! no commits found for your email in this rep !!![/yellow]")
-        console.print(f"[dim]make sure you have commits with {corporate_email}[/dim]")
-        return
+        _die(f"no commits found for {corporate_email} in this repo",
+             f"make sure you have commits with {corporate_email}")
 
-    console.print(f"[green]✨ found {len(commits)} commits by you[/green]\n")
+    if plain:
+        console.print(f"found {len(commits)} commits by {corporate_email}")
+    else:
+        console.print(f"[green]✨ found {len(commits)} commits by you[/green]\n")
 
     # show preview and ask for confirmation
     date_start = commits[-1]['date'].strftime('%Y-%m-%d')
     date_end = commits[0]['date'].strftime('%Y-%m-%d')
 
-    console.print(Panel.fit(
-        f"[bold]ready to create:[/bold]\n"
-        f"• repo: github.com/{personal_username}/{mirror_repo_name}\n"
-        f"• commits: {len(commits)} empty commits\n"
-        f"• visibility: {'private' if private else 'public'}\n"
-        f"• date range: {date_start} to {date_end}",
-        title="Summary",
-        border_style="cyan"
-    ))
+    if plain:
+        console.print(
+            f"plan: {len(commits)} empty commits -> "
+            f"github.com/{username}/{mirror_repo_name} "
+            f"({'private' if private else 'public'}), {date_start} to {date_end}"
+        )
+    else:
+        console.print(Panel.fit(
+            f"[bold]ready to create:[/bold]\n"
+            f"• repo: github.com/{username}/{mirror_repo_name}\n"
+            f"• commits: {len(commits)} empty commits\n"
+            f"• visibility: {'private' if private else 'public'}\n"
+            f"• date range: {date_start} to {date_end}",
+            title="Summary",
+            border_style="cyan"
+        ))
 
     if dry_run:
-        console.print("\n[yellow]DRY RUN MODE - nothing will actually be created[/yellow]")
-        console.print("[dim]run without --dry-run to actually do it[/dim]")
+        if plain:
+            console.print("dry-run complete; run without --dry-run to actually do it")
+        else:
+            console.print("\n[yellow]DRY RUN MODE - nothing will actually be created[/yellow]")
+            console.print("[dim]run without --dry-run to actually do it[/dim]")
         return
 
     # ask for confirmation
-    if not click.confirm("\nproceed with creating the mirror repo?", default=True):
-        console.print("[yellow]operation cancelled[/yellow]")
-        return
+    if not assume_yes:
+        if not click.confirm("\nproceed with creating the mirror repo?", default=True):
+            console.print("[yellow]operation cancelled[/yellow]")
+            return
 
-    console.print()
+    if not plain:
+        console.print()
 
     console.print("[cyan]checking if repository exists...[/cyan]")
-    exists, has_access, error = check_repo_exists(personal_username, mirror_repo_name, token)
+    exists, has_access, error = check_repo_exists(username, mirror_repo_name, token)
 
     if exists and has_access:
-        console.print(f"[green]✓ found existing repo: github.com/{personal_username}/{mirror_repo_name}[/green]")
+        console.print(f"[green]✓ found existing repo: github.com/{username}/{mirror_repo_name}[/green]")
         console.print("[dim]will add commits to the existing repository[/dim]\n")
     elif exists and not has_access:
-        console.print(f"[red]!!! repository exists but your token doesn't have access to it[/red]")
-        console.print(f"[yellow]make sure your token has access to github.com/{personal_username}/{mirror_repo_name}[/yellow]")
-        return
+        _die("repository exists but your token doesn't have access to it",
+             f"make sure your token has access to github.com/{username}/{mirror_repo_name}")
     else:
         console.print("[cyan]repository doesn't exist, creating it...[/cyan]")
-        if not create_github_repo(personal_username, mirror_repo_name, token, private):
-            return
+        if not create_github_repo(username, mirror_repo_name, token, private):
+            sys.exit(1)
 
         # GH rate limit, wait for it to catch up
         time.sleep(2)
 
     # get the initial branch SHA
-    parent_sha = get_main_branch_sha(personal_username, mirror_repo_name, token)
+    parent_sha = get_main_branch_sha(username, mirror_repo_name, token)
 
     # create all the commits
     console.print(f"\n[cyan]creating {len(commits)} empty commits...[/cyan]")
@@ -182,42 +266,65 @@ def cli(private, dry_run):
         key=lambda x: x['date'].astimezone(timezone.utc) if x['date'].tzinfo else x['date'].replace(tzinfo=timezone.utc)
     )
 
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        console=console
-    ) as progress:
-        task = progress.add_task("mirroring commits...", total=len(commits_sorted))
+    def _mirror_commit(index, commit):
+        """Create one empty commit and advance the branch. Returns True on success."""
+        new_sha, err = create_empty_commit(
+            username,
+            mirror_repo_name,
+            commit['date'],
+            token,
+            parent_sha
+        )
+        if new_sha:
+            if update_branch_ref(username, mirror_repo_name, token, new_sha):
+                return new_sha, None
+            return None, err or "couldn't update branch"
+        return None, err or "unknown error"
 
+    if plain:
+        # no animated progress bar for pipes/CI; emit periodic plain updates instead
+        total = len(commits_sorted)
         for i, commit in enumerate(commits_sorted):
-            new_sha, error = create_empty_commit(
-                personal_username,
-                mirror_repo_name,
-                commit['date'],
-                token,
-                parent_sha
-            )
-
+            new_sha, err = _mirror_commit(i, commit)
             if new_sha:
-                # update the branch to point to this new commit
-                if update_branch_ref(personal_username, mirror_repo_name, token, new_sha):
-                    parent_sha = new_sha  # this becomes the parent for the next commit
-                    success_count += 1
-                else:
-                    failed_commits.append((i, error or "couldn't update branch"))
+                parent_sha = new_sha
+                success_count += 1
             else:
-                failed_commits.append((i, error or "unknown error"))
+                failed_commits.append((i, err))
 
-            progress.update(task, advance=1)
+            # progress heartbeat so long runs aren't silent
+            if (i + 1) % 25 == 0 or (i + 1) == total:
+                console.print(f"  {i + 1}/{total} commits mirrored")
 
             # be nice to GitHub's API (rate limiting)
             if i % 10 == 0 and i > 0:
                 time.sleep(1)
+    else:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            console=console
+        ) as progress:
+            task = progress.add_task("mirroring commits...", total=len(commits_sorted))
+
+            for i, commit in enumerate(commits_sorted):
+                new_sha, err = _mirror_commit(i, commit)
+                if new_sha:
+                    parent_sha = new_sha
+                    success_count += 1
+                else:
+                    failed_commits.append((i, err))
+
+                progress.update(task, advance=1)
+
+                # be nice to GitHub's API (rate limiting)
+                if i % 10 == 0 and i > 0:
+                    time.sleep(1)
 
     # create a rich README for the repo
     console.print("\n[cyan]creating README.md...[/cyan]")
     readme_content = create_readme_content(
-        username=personal_username,
+        username=username,
         repo_name=mirror_repo_name,
         num_commits=success_count,
         date_range_start=date_start,
@@ -225,35 +332,49 @@ def cli(private, dry_run):
         original_repo=repo_name
     )
 
-    readme_created = update_repo_readme(personal_username, mirror_repo_name, token, readme_content)
+    readme_created = update_repo_readme(username, mirror_repo_name, token, readme_content)
     if readme_created:
         console.print("[green]README created[/green]")
     else:
         console.print("[yellow]couldn't create README (you can add it manually)[/yellow]")
 
     # show results
-    console.print()
+    repo_url = f"github.com/{username}/{mirror_repo_name}"
+    if not plain:
+        console.print()
     if success_count == len(commits):
-        console.print(Panel.fit(
-            f"[bold green]SUCCESS![/bold green]\n\n"
-            f"mirrored {success_count} commits to your personal GitHub.\n"
-            f"check it out: [link=https://github.com/{personal_username}/{mirror_repo_name}]github.com/{personal_username}/{mirror_repo_name}[/link]\n\n"
-            f"[dim]your contribution graph should update in a few minutes[/dim]",
-            border_style="green"
-        ))
+        if plain:
+            console.print(f"success: mirrored {success_count} commits to {repo_url}")
+        else:
+            console.print(Panel.fit(
+                f"[bold green]SUCCESS![/bold green]\n\n"
+                f"mirrored {success_count} commits to your personal GitHub.\n"
+                f"check it out: [link=https://{repo_url}]{repo_url}[/link]\n\n"
+                f"[dim]your contribution graph should update in a few minutes[/dim]",
+                border_style="green"
+            ))
     else:
-        console.print(Panel.fit(
-            f"[bold yellow]PARTIAL SUCCESS[/bold yellow]\n\n"
-            f"created {success_count}/{len(commits)} commits\n"
-            f"failed: {len(failed_commits)} commits\n\n"
-            f"repo: [link=https://github.com/{personal_username}/{mirror_repo_name}]github.com/{personal_username}/{mirror_repo_name}[/link]",
-            border_style="yellow"
-        ))
+        if plain:
+            console.print(
+                f"partial: created {success_count}/{len(commits)} commits, "
+                f"{len(failed_commits)} failed -> {repo_url}"
+            )
+        else:
+            console.print(Panel.fit(
+                f"[bold yellow]PARTIAL SUCCESS[/bold yellow]\n\n"
+                f"created {success_count}/{len(commits)} commits\n"
+                f"failed: {len(failed_commits)} commits\n\n"
+                f"repo: [link=https://{repo_url}]{repo_url}[/link]",
+                border_style="yellow"
+            ))
 
         if failed_commits and len(failed_commits) < 10:
             console.print("\n[dim]failed commits:[/dim]")
-            for idx, error in failed_commits[:5]:
-                console.print(f"[dim]  • commit {idx + 1}: {error}[/dim]")
+            for idx, err in failed_commits[:5]:
+                console.print(f"[dim]  • commit {idx + 1}: {err}[/dim]")
+
+        # signal failure to callers/CI
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/shomei/cli.py
+++ b/shomei/cli.py
@@ -8,6 +8,8 @@ import sys
 import time
 from contextlib import nullcontext
 from datetime import timezone
+from pathlib import Path
+from urllib.parse import urlsplit
 import click
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -16,18 +18,85 @@ from rich.panel import Panel
 from . import __version__
 from .art import print_logo
 from .validators import validate_repo_name, validate_github_token, validate_github_username
-from .git_utils import get_git_user_email, get_repo_name, get_commits_by_author, get_git_user_name
+from .git_utils import (
+    get_git_remote_url,
+    get_git_root,
+    get_git_user_email,
+    get_repo_name,
+    get_commits_by_author,
+    get_git_user_name,
+)
 from .github_api import (
     check_repo_exists,
     create_github_repo,
     get_main_branch_sha,
+    get_mirrored_commit_dates,
     create_empty_commit,
     update_branch_ref,
     update_repo_readme
 )
 from .readme_generator import create_readme_content
+from .sync_state import (
+    SyncStateError,
+    get_state_path,
+    get_sync_record,
+    load_state,
+    mark_commit_synced,
+    save_state,
+)
 
 console = Console()
+
+
+def _as_utc(commit_date):
+    """Make a commit date safe to compare with other Git dates."""
+    if commit_date.tzinfo:
+        return commit_date.astimezone(timezone.utc)
+    return commit_date.replace(tzinfo=timezone.utc)
+
+
+def _split_legacy_mirror_commits(commits, mirrored_dates):
+    """Match old mirror timestamps without collapsing duplicate timestamps."""
+    remaining_dates = list(mirrored_dates)
+    new_commits = []
+    already_mirrored = []
+
+    for commit in commits:
+        source_date = commit['date']
+        source_utc = _as_utc(source_date).replace(microsecond=0)
+        source_wall_time = source_date.replace(tzinfo=None).replace(microsecond=0)
+
+        match_index = next(
+            (
+                index for index, mirrored_date in enumerate(remaining_dates)
+                if (
+                    _as_utc(mirrored_date).replace(microsecond=0) == source_utc
+                    or _as_utc(mirrored_date).replace(tzinfo=None).replace(microsecond=0)
+                    == source_wall_time
+                )
+            ),
+            None,
+        )
+        if match_index is None:
+            new_commits.append(commit)
+        else:
+            already_mirrored.append(commit)
+            remaining_dates.pop(match_index)
+
+    return new_commits, already_mirrored
+
+
+def _source_repository_identity(remote_url, repo_name, repo_root):
+    """Keep credentials out of the source identity stored in local state."""
+    if not remote_url:
+        return f"local:{repo_root or repo_name}"
+
+    parsed_url = urlsplit(remote_url)
+    if parsed_url.scheme and parsed_url.hostname:
+        return f"{parsed_url.scheme}://{parsed_url.hostname}{parsed_url.path}"
+    if "@" in remote_url:
+        return remote_url.split("@", 1)[1]
+    return remote_url
 
 
 def _die(message, hint=None):
@@ -190,31 +259,83 @@ def cli(private, dry_run, username, mirror_repo_name, token, email, display_name
         _die(f"no commits found for {corporate_email} in this repo",
              f"make sure you have commits with {corporate_email}")
 
+    # Keep source commit hashes locally so a later invocation only mirrors
+    # commits that were not completed by an earlier invocation.  The state is
+    # kept per source/email/target combination because one source repository
+    # can legitimately be mirrored to multiple personal repositories.
+    repo_root = get_git_root()
+    state_path = get_state_path(Path(repo_root) if repo_root else Path.cwd())
+    source_repository = _source_repository_identity(
+        get_git_remote_url(),
+        repo_name,
+        repo_root,
+    )
+    target_repository = f"{username}/{mirror_repo_name}"
+    try:
+        sync_state = load_state(state_path)
+        sync_record = get_sync_record(
+            sync_state,
+            target_repository,
+            source_repository,
+            corporate_email,
+        )
+    except SyncStateError as error:
+        _die(str(error))
+
+    synced_hashes = set(sync_record["commits"])
+    commits_to_mirror = [
+        commit for commit in commits if commit["hash"] not in synced_hashes
+    ]
+
     if plain:
         console.print(f"found {len(commits)} commits by {corporate_email}")
+        if synced_hashes:
+            console.print(
+                f"already mirrored {len(synced_hashes)} commits; "
+                f"{len(commits_to_mirror)} new commits to sync"
+            )
     else:
         console.print(f"[green]✨ found {len(commits)} commits by you[/green]\n")
+        if synced_hashes:
+            console.print(
+                f"[dim]already mirrored {len(synced_hashes)} commits; "
+                f"{len(commits_to_mirror)} new commits to sync[/dim]\n"
+            )
 
     # show preview and ask for confirmation
-    date_start = commits[-1]['date'].strftime('%Y-%m-%d')
-    date_end = commits[0]['date'].strftime('%Y-%m-%d')
+    preview_commits = commits_to_mirror or commits
+    preview_dates = sorted((commit['date'] for commit in preview_commits), key=_as_utc)
+    date_start = preview_dates[0].strftime('%Y-%m-%d')
+    date_end = preview_dates[-1].strftime('%Y-%m-%d')
 
     if plain:
-        console.print(
-            f"plan: {len(commits)} empty commits -> "
-            f"github.com/{username}/{mirror_repo_name} "
-            f"({'private' if private else 'public'}), {date_start} to {date_end}"
-        )
+        if commits_to_mirror:
+            console.print(
+                f"plan: {len(commits_to_mirror)} new empty commits -> "
+                f"github.com/{username}/{mirror_repo_name} "
+                f"({'private' if private else 'public'}), {date_start} to {date_end}"
+            )
+        else:
+            console.print(
+                f"plan: already up to date -> "
+                f"github.com/{username}/{mirror_repo_name} "
+                f"({len(commits)} commits mirrored)"
+            )
     else:
-        console.print(Panel.fit(
+        summary = (
             f"[bold]ready to create:[/bold]\n"
             f"• repo: github.com/{username}/{mirror_repo_name}\n"
-            f"• commits: {len(commits)} empty commits\n"
+            f"• commits: {len(commits_to_mirror)} new empty commits\n"
             f"• visibility: {'private' if private else 'public'}\n"
-            f"• date range: {date_start} to {date_end}",
-            title="Summary",
-            border_style="cyan"
-        ))
+            f"• date range: {date_start} to {date_end}"
+            if commits_to_mirror
+            else (
+                f"[bold]nothing new to sync:[/bold]\n"
+                f"• repo: github.com/{username}/{mirror_repo_name}\n"
+                f"• commits: {len(commits)} already mirrored"
+            )
+        )
+        console.print(Panel.fit(summary, title="Summary", border_style="cyan"))
 
     if dry_run:
         if plain:
@@ -238,7 +359,45 @@ def cli(private, dry_run, username, mirror_repo_name, token, email, display_name
 
     if exists and has_access:
         console.print(f"[green]✓ found existing repo: github.com/{username}/{mirror_repo_name}[/green]")
-        console.print("[dim]will add commits to the existing repository[/dim]\n")
+
+        # Repositories created by older shōmei versions have no local state.
+        # Use their generated commit timestamps once to seed the hash-based
+        # state, while keeping duplicate timestamps as separate commits.
+        if not synced_hashes and commits_to_mirror:
+            legacy_dates = get_mirrored_commit_dates(
+                username,
+                mirror_repo_name,
+                token,
+            )
+            if legacy_dates is not None:
+                commits_to_mirror, legacy_commits = _split_legacy_mirror_commits(
+                    commits_to_mirror,
+                    legacy_dates,
+                )
+                if legacy_commits:
+                    for commit in legacy_commits:
+                        mark_commit_synced(
+                            sync_state,
+                            target_repository,
+                            source_repository,
+                            corporate_email,
+                            commit['hash'],
+                            commit['date'],
+                            None,
+                        )
+                    try:
+                        save_state(state_path, sync_state)
+                    except SyncStateError as error:
+                        _die(f"couldn't save migrated sync state: {error}")
+                    console.print(
+                        f"[dim]migrated {len(legacy_commits)} existing mirror commits "
+                        "into local sync state[/dim]"
+                    )
+
+        if not commits_to_mirror:
+            console.print("[dim]already up to date; no new commits to add[/dim]")
+            return
+        console.print("[dim]will add new commits to the existing repository[/dim]\n")
     elif exists and not has_access:
         _die("repository exists but your token doesn't have access to it",
              f"make sure your token has access to github.com/{username}/{mirror_repo_name}")
@@ -250,23 +409,22 @@ def cli(private, dry_run, username, mirror_repo_name, token, email, display_name
         # GH rate limit, wait for it to catch up
         time.sleep(2)
 
+        # A local state file can outlive a deleted mirror repository.  The
+        # replacement repository has no mirrored history, so rebuild it.
+        if not commits_to_mirror:
+            commits_to_mirror = list(commits)
+
     # get the initial branch SHA
     parent_sha = get_main_branch_sha(username, mirror_repo_name, token)
 
     # create all the commits
-    console.print(f"\n[cyan]creating {len(commits)} empty commits...[/cyan]")
+    total_to_mirror = len(commits_to_mirror)
+    console.print(f"\n[cyan]creating {total_to_mirror} empty commits...[/cyan]")
 
     success_count = 0
     failed_commits = []
 
-    # sort commits chronologically (oldest first)
-    # ensure all datetimes are timezone-aware to avoid comparison errors
-    commits_sorted = sorted(
-        commits,
-        key=lambda x: x['date'].astimezone(timezone.utc) if x['date'].tzinfo else x['date'].replace(tzinfo=timezone.utc)
-    )
-
-    def _mirror_commit(index, commit):
+    def _mirror_commit(commit):
         """Create one empty commit and advance the branch. Returns True on success."""
         new_sha, err = create_empty_commit(
             username,
@@ -277,15 +435,37 @@ def cli(private, dry_run, username, mirror_repo_name, token, email, display_name
         )
         if new_sha:
             if update_branch_ref(username, mirror_repo_name, token, new_sha):
+                try:
+                    mark_commit_synced(
+                        sync_state,
+                        target_repository,
+                        source_repository,
+                        corporate_email,
+                        commit['hash'],
+                        commit['date'],
+                        new_sha,
+                    )
+                    save_state(state_path, sync_state)
+                except SyncStateError as error:
+                    _die(
+                        f"mirrored commit {commit['hash'][:12]}, but couldn't persist "
+                        f"sync state: {error}",
+                        "the remote branch was updated; restore the state file before retrying",
+                    )
                 return new_sha, None
             return None, err or "couldn't update branch"
         return None, err or "unknown error"
 
+    commits_sorted = sorted(
+        commits_to_mirror,
+        key=lambda x: _as_utc(x['date'])
+    )
+
     if plain:
         # no animated progress bar for pipes/CI; emit periodic plain updates instead
-        total = len(commits_sorted)
+        total = total_to_mirror
         for i, commit in enumerate(commits_sorted):
-            new_sha, err = _mirror_commit(i, commit)
+            new_sha, err = _mirror_commit(commit)
             if new_sha:
                 parent_sha = new_sha
                 success_count += 1
@@ -308,7 +488,7 @@ def cli(private, dry_run, username, mirror_repo_name, token, email, display_name
             task = progress.add_task("mirroring commits...", total=len(commits_sorted))
 
             for i, commit in enumerate(commits_sorted):
-                new_sha, err = _mirror_commit(i, commit)
+                new_sha, err = _mirror_commit(commit)
                 if new_sha:
                     parent_sha = new_sha
                     success_count += 1
@@ -323,12 +503,14 @@ def cli(private, dry_run, username, mirror_repo_name, token, email, display_name
 
     # create a rich README for the repo
     console.print("\n[cyan]creating README.md...[/cyan]")
+    synced_count = len(sync_record["commits"])
+    source_dates = sorted((commit['date'] for commit in commits), key=_as_utc)
     readme_content = create_readme_content(
         username=username,
         repo_name=mirror_repo_name,
-        num_commits=success_count,
-        date_range_start=date_start,
-        date_range_end=date_end,
+        num_commits=synced_count,
+        date_range_start=source_dates[0].strftime('%Y-%m-%d'),
+        date_range_end=source_dates[-1].strftime('%Y-%m-%d'),
         original_repo=repo_name
     )
 
@@ -342,13 +524,17 @@ def cli(private, dry_run, username, mirror_repo_name, token, email, display_name
     repo_url = f"github.com/{username}/{mirror_repo_name}"
     if not plain:
         console.print()
-    if success_count == len(commits):
+    if success_count == total_to_mirror:
         if plain:
-            console.print(f"success: mirrored {success_count} commits to {repo_url}")
+            console.print(
+                f"success: mirrored {success_count} new commits to {repo_url} "
+                f"({synced_count} total)"
+            )
         else:
             console.print(Panel.fit(
                 f"[bold green]SUCCESS![/bold green]\n\n"
-                f"mirrored {success_count} commits to your personal GitHub.\n"
+                f"mirrored {success_count} new commits to your personal GitHub.\n"
+                f"{synced_count} commits mirrored in total.\n"
                 f"check it out: [link=https://{repo_url}]{repo_url}[/link]\n\n"
                 f"[dim]your contribution graph should update in a few minutes[/dim]",
                 border_style="green"
@@ -356,13 +542,13 @@ def cli(private, dry_run, username, mirror_repo_name, token, email, display_name
     else:
         if plain:
             console.print(
-                f"partial: created {success_count}/{len(commits)} commits, "
+                f"partial: created {success_count}/{total_to_mirror} new commits, "
                 f"{len(failed_commits)} failed -> {repo_url}"
             )
         else:
             console.print(Panel.fit(
                 f"[bold yellow]PARTIAL SUCCESS[/bold yellow]\n\n"
-                f"created {success_count}/{len(commits)} commits\n"
+                f"created {success_count}/{total_to_mirror} new commits\n"
                 f"failed: {len(failed_commits)} commits\n\n"
                 f"repo: [link=https://{repo_url}]{repo_url}[/link]",
                 border_style="yellow"

--- a/shomei/git_utils.py
+++ b/shomei/git_utils.py
@@ -4,6 +4,34 @@ import subprocess
 from datetime import datetime, timezone
 
 
+def get_git_root():
+    """Return the top-level directory of the current Git repository."""
+    try:
+        result = subprocess.run(
+            ['git', 'rev-parse', '--show-toplevel'],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        return None
+
+
+def get_git_remote_url():
+    """Return the origin URL, or ``None`` when the repository has no origin."""
+    try:
+        result = subprocess.run(
+            ['git', 'remote', 'get-url', 'origin'],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip() or None
+    except subprocess.CalledProcessError:
+        return None
+
+
 def get_git_user_email():
     """
     Get the current git user email from git config.
@@ -42,9 +70,9 @@ def get_repo_name():
         str: The repository name, or "unknown-repo" if not found
     """
     try:
-        result = subprocess.run(['git', 'remote', 'get-url', 'origin'],
-                              capture_output=True, text=True, check=True)
-        url = result.stdout.strip()
+        url = get_git_remote_url()
+        if not url:
+            return "unknown-repo"
         # extract repo name from URLs like: https://github.com/user/repo.git
         return url.split('/')[-1].replace('.git', '')
     except subprocess.CalledProcessError:
@@ -89,4 +117,3 @@ def get_commits_by_author(email):
         return commits
     except subprocess.CalledProcessError:
         return []
-

--- a/shomei/github_api.py
+++ b/shomei/github_api.py
@@ -1,10 +1,20 @@
 """GitHub API operations for shōmei."""
 
 import base64
+from datetime import datetime, timezone
 import requests
 from rich.console import Console
 
 console = Console()
+
+
+def _github_date(date):
+    """Format a commit date as a UTC timestamp for GitHub's API."""
+    if date.tzinfo is None:
+        date = date.replace(tzinfo=timezone.utc)
+    else:
+        date = date.astimezone(timezone.utc)
+    return date.strftime('%Y-%m-%dT%H:%M:%SZ')
 
 
 def check_repo_exists(username, repo_name, token):
@@ -141,6 +151,61 @@ def get_main_branch_sha(username, repo_name, token):
     return None
 
 
+def get_mirrored_commit_dates(username, repo_name, token):
+    """Return dates for existing shōmei commits in a mirror repository.
+
+    This is used only to migrate repositories created before local state was
+    introduced.  ``None`` means the history could not be read; an empty list
+    is a successfully-read repository with no shōmei commits.
+    """
+    url = f"https://api.github.com/repos/{username}/{repo_name}/commits"
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json"
+    }
+    dates = []
+    page = 1
+    per_page = 100
+
+    try:
+        while True:
+            response = requests.get(
+                url,
+                headers=headers,
+                params={"sha": "main", "page": page, "per_page": per_page},
+                timeout=10,
+            )
+            if response.status_code != 200:
+                return None
+
+            commits = response.json()
+            if not isinstance(commits, list):
+                return None
+
+            for commit in commits:
+                commit_data = commit.get("commit", {})
+                if not isinstance(commit_data, dict):
+                    continue
+                message = commit_data.get("message", "")
+                if not message.startswith("ci(shōmei): sync work contribution"):
+                    continue
+
+                author = commit_data.get("author", {})
+                date_string = author.get("date") if isinstance(author, dict) else None
+                if not date_string:
+                    continue
+                try:
+                    dates.append(datetime.fromisoformat(date_string.replace("Z", "+00:00")))
+                except ValueError:
+                    continue
+
+            if len(commits) < per_page:
+                return dates
+            page += 1
+    except (requests.exceptions.RequestException, ValueError, TypeError):
+        return None
+
+
 def create_empty_commit(username, repo_name, date, token, parent_sha=None):
     """
     Create an empty commit via GitHub API.
@@ -191,12 +256,12 @@ def create_empty_commit(username, repo_name, date, token, parent_sha=None):
             "author": {
                 "name": username,
                 "email": f"{username}@users.noreply.github.com",
-                "date": date.strftime('%Y-%m-%dT%H:%M:%SZ')
+                "date": _github_date(date)
             },
             "committer": {
                 "name": username,
                 "email": f"{username}@users.noreply.github.com",
-                "date": date.strftime('%Y-%m-%dT%H:%M:%SZ')
+                "date": _github_date(date)
             }
         }
 

--- a/shomei/sync_state.py
+++ b/shomei/sync_state.py
@@ -1,0 +1,152 @@
+"""Persistent state for incremental shōmei synchronizations.
+
+The state file contains source commit hashes and the corresponding mirror
+commit hashes.  It deliberately does not contain commit messages, paths, or
+any other source-repository content.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+STATE_VERSION = 1
+STATE_DIRECTORY = ".shomei"
+STATE_FILENAME = "state.json"
+
+
+class SyncStateError(RuntimeError):
+    """Raised when the local sync state cannot be read or written safely."""
+
+
+def get_state_path(repo_root: Path | None = None) -> Path:
+    """Return the state path for a source repository."""
+
+    root = repo_root or Path.cwd()
+    return root / STATE_DIRECTORY / STATE_FILENAME
+
+
+def _new_state() -> dict[str, Any]:
+    return {"version": STATE_VERSION, "syncs": {}}
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    """Load state from *path*, returning an empty state when it is absent."""
+
+    if not path.exists():
+        return _new_state()
+
+    try:
+        with path.open("r", encoding="utf-8") as state_file:
+            state = json.load(state_file)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SyncStateError(f"couldn't read sync state at {path}: {exc}") from exc
+
+    if not isinstance(state, dict) or state.get("version") != STATE_VERSION:
+        raise SyncStateError(
+            f"unsupported or invalid sync state at {path}; "
+            "remove it only if you are willing to mirror the history again"
+        )
+    if not isinstance(state.get("syncs"), dict):
+        raise SyncStateError(f"invalid sync state at {path}: 'syncs' must be an object")
+
+    return state
+
+
+def _source_key(source_repository: str, author_email: str) -> str:
+    """Build a stable, unambiguous key for one source/email pair."""
+
+    return json.dumps(
+        {"author_email": author_email, "source_repository": source_repository},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def get_sync_record(
+    state: dict[str, Any],
+    target: str,
+    source_repository: str,
+    author_email: str,
+) -> dict[str, Any]:
+    """Return the mutable state record for one source and mirror target."""
+
+    syncs = state.setdefault("syncs", {})
+    target_state = syncs.setdefault(target, {"sources": {}})
+    if not isinstance(target_state, dict):
+        raise SyncStateError(f"invalid state for mirror target {target}")
+
+    sources = target_state.setdefault("sources", {})
+    if not isinstance(sources, dict):
+        raise SyncStateError(f"invalid source state for mirror target {target}")
+
+    source_key = _source_key(source_repository, author_email)
+    record = sources.setdefault(
+        source_key,
+        {
+            "source_repository": source_repository,
+            "author_email": author_email,
+            "commits": {},
+        },
+    )
+    if not isinstance(record, dict):
+        raise SyncStateError(f"invalid source state for mirror target {target}")
+
+    commits = record.setdefault("commits", {})
+    if not isinstance(commits, dict):
+        raise SyncStateError(f"invalid commit state for mirror target {target}")
+
+    return record
+
+
+def mark_commit_synced(
+    state: dict[str, Any],
+    target: str,
+    source_repository: str,
+    author_email: str,
+    source_commit_hash: str,
+    commit_date: datetime,
+    mirror_commit_sha: str | None,
+) -> None:
+    """Record a source commit after its mirror branch has been updated."""
+
+    record = get_sync_record(state, target, source_repository, author_email)
+    record["commits"][source_commit_hash] = {
+        "date": commit_date.isoformat(),
+        "mirror_sha": mirror_commit_sha,
+    }
+    record["last_synced_at"] = datetime.now(timezone.utc).isoformat()
+
+
+def save_state(path: Path, state: dict[str, Any]) -> None:
+    """Atomically save state so an interrupted write cannot corrupt it."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: str | None = None
+
+    try:
+        file_descriptor, temporary_path = tempfile.mkstemp(
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            dir=path.parent,
+        )
+        with os.fdopen(file_descriptor, "w", encoding="utf-8") as state_file:
+            json.dump(state, state_file, ensure_ascii=False, indent=2, sort_keys=True)
+            state_file.write("\n")
+            state_file.flush()
+            os.fsync(state_file.fileno())
+        os.replace(temporary_path, path)
+        temporary_path = None
+    except OSError as exc:
+        raise SyncStateError(f"couldn't save sync state at {path}: {exc}") from exc
+    finally:
+        if temporary_path:
+            try:
+                os.unlink(temporary_path)
+            except OSError:
+                pass

--- a/tests/test_incremental_sync.py
+++ b/tests/test_incremental_sync.py
@@ -1,0 +1,138 @@
+from datetime import datetime, timedelta, timezone
+import importlib
+
+from click.testing import CliRunner
+
+from shomei.sync_state import (
+    get_sync_record,
+    load_state,
+    mark_commit_synced,
+    save_state,
+)
+from shomei.github_api import _github_date
+
+
+cli_module = importlib.import_module("shomei.cli")
+
+
+def _commit(commit_hash, day):
+    return {
+        "hash": commit_hash,
+        "date": datetime(2025, 1, day, 12, tzinfo=timezone.utc),
+    }
+
+
+def test_sync_state_round_trip_records_source_and_mirror_hashes(tmp_path):
+    state_path = tmp_path / ".shomei" / "state.json"
+    state = load_state(state_path)
+
+    mark_commit_synced(
+        state,
+        "me/work-mirror",
+        "https://github.com/company/work.git",
+        "work@example.com",
+        "source-1",
+        _commit("source-1", 1)["date"],
+        "mirror-1",
+    )
+    save_state(state_path, state)
+
+    loaded = load_state(state_path)
+    record = get_sync_record(
+        loaded,
+        "me/work-mirror",
+        "https://github.com/company/work.git",
+        "work@example.com",
+    )
+    assert record["commits"] == {
+        "source-1": {
+            "date": "2025-01-01T12:00:00+00:00",
+            "mirror_sha": "mirror-1",
+        }
+    }
+
+
+def test_legacy_timestamp_matching_preserves_duplicate_commits():
+    source_commits = [_commit("source-1", 1), _commit("source-2", 1), _commit("source-3", 2)]
+    mirrored_dates = [
+        datetime(2025, 1, 1, 12, tzinfo=timezone.utc),
+        datetime(2025, 1, 1, 12, tzinfo=timezone.utc),
+    ]
+
+    new_commits, already_mirrored = cli_module._split_legacy_mirror_commits(
+        source_commits,
+        mirrored_dates,
+    )
+
+    assert [commit["hash"] for commit in already_mirrored] == ["source-1", "source-2"]
+    assert [commit["hash"] for commit in new_commits] == ["source-3"]
+
+
+def test_github_dates_are_serialized_in_utc():
+    local_date = datetime(2025, 1, 1, 12, tzinfo=timezone(timedelta(hours=1)))
+    assert _github_date(local_date) == "2025-01-01T11:00:00Z"
+
+
+def test_cli_only_mirrors_new_commits_on_later_runs(monkeypatch, tmp_path):
+    commits = [_commit("source-1", 1), _commit("source-2", 2)]
+    created = []
+    parent_shas = []
+
+    monkeypatch.setattr(cli_module, "validate_github_username", lambda _: (True, "ok"))
+    monkeypatch.setattr(cli_module, "validate_github_token", lambda _: (True, None))
+    monkeypatch.setattr(cli_module, "get_git_user_name", lambda: "Developer")
+    monkeypatch.setattr(cli_module, "get_repo_name", lambda: "work")
+    monkeypatch.setattr(cli_module, "get_git_root", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        cli_module,
+        "get_git_remote_url",
+        lambda: "https://github.com/company/work.git",
+    )
+    monkeypatch.setattr(cli_module, "get_commits_by_author", lambda _: list(commits))
+    monkeypatch.setattr(cli_module, "check_repo_exists", lambda *_: (True, True, None))
+    monkeypatch.setattr(cli_module, "get_mirrored_commit_dates", lambda *_: [])
+    monkeypatch.setattr(cli_module, "get_main_branch_sha", lambda *_: "remote-head")
+    monkeypatch.setattr(cli_module, "time", type("NoSleep", (), {"sleep": staticmethod(lambda _: None)}))
+    monkeypatch.setattr(cli_module, "update_branch_ref", lambda *_: True)
+    monkeypatch.setattr(cli_module, "update_repo_readme", lambda *_: True)
+
+    def fake_create_empty_commit(username, repo_name, date, token, parent_sha):
+        created.append(date)
+        parent_shas.append(parent_sha)
+        return f"mirror-{len(created)}", None
+
+    monkeypatch.setattr(cli_module, "create_empty_commit", fake_create_empty_commit)
+
+    runner = CliRunner()
+    args = [
+        "--username", "me",
+        "--repo-name", "work-mirror",
+        "--token", "test-token",
+        "--email", "work@example.com",
+        "--non-interactive",
+    ]
+
+    first = runner.invoke(cli_module.cli, args)
+    assert first.exit_code == 0, first.output
+    assert len(created) == 2
+
+    commits.append(_commit("source-3", 3))
+    second = runner.invoke(cli_module.cli, args)
+    assert second.exit_code == 0, second.output
+    assert len(created) == 3
+    assert "1 new commits" in second.output
+
+    third = runner.invoke(cli_module.cli, args)
+    assert third.exit_code == 0, third.output
+    assert len(created) == 3
+    assert "already up to date" in third.output
+
+    state = load_state(tmp_path / ".shomei" / "state.json")
+    record = get_sync_record(
+        state,
+        "me/work-mirror",
+        "https://github.com/company/work.git",
+        "work@example.com",
+    )
+    assert set(record["commits"]) == {"source-1", "source-2", "source-3"}
+    assert parent_shas == ["remote-head", "mirror-1", "remote-head"]


### PR DESCRIPTION
Adds the possibility of passing all flags uninteractively through CLI usage instead of requiring input from the user.. 

Useful for scripts that may sync multiple repos, cronjobs and use in other scripts.

Interactive and non-interactive mode could maybe be split into two functions? I don't really know the cleanest way to approach this. 